### PR TITLE
fix: formato del response del ProductoResource corregido

### DIFF
--- a/app/Http/Controllers/Api/V1/Producto/ProductoController.php
+++ b/app/Http/Controllers/Api/V1/Producto/ProductoController.php
@@ -103,7 +103,7 @@ class ProductoController extends Controller
                 ->orderBy('created_at')
                 ->get();
 
-            $showProductos = $productos->map(function ($producto) {
+            /* $showProductos = $productos->map(function ($producto) {
                 // $especificacionesFormateadas = [];
                 // foreach ($producto->especificaciones as $especificacion) {
                 //     $especificacionesFormateadas[$especificacion->clave] = $especificacion->valor;
@@ -160,9 +160,9 @@ class ProductoController extends Controller
                 ];
             });
 
-            return response()->json($showProductos);
+            return response()->json($showProductos); */
 
-            //return ProductoResource::collection($productos);
+            return ProductoResource::collection($productos)->resolve();
         } catch (\Exception $e) {
             return response()->json([
                 'message' => 'Error al obtener los productos: ' . $e->getMessage()
@@ -427,7 +427,7 @@ class ProductoController extends Controller
                 ], 404);
             }
 
-            $imagenes = $producto->imagenes->map(function ($imagen) {
+            /* $imagenes = $producto->imagenes->map(function ($imagen) {
                 return [
                     'url_imagen' => $imagen->url_imagen,
                     'texto_alt_SEO' => $imagen->texto_alt_SEO,
@@ -456,12 +456,12 @@ class ProductoController extends Controller
                     'largo' => $producto->dimensiones->largo,
                     'ancho' => $producto->dimensiones->ancho,
                 ] : null,
-            ];
-
+            ]; */
+            //Con el argumento false indicamos que no use el ProductoRelacionadoResource de esta manera no mapea datos innecesarios
             return response()->json([
                 'message' => 'Producto encontrado exitosamente',
-                'data' => $formattedProducto
-                //'data' => new ProductoResource($producto)
+                //'data' => $formattedProducto
+                'data' => new ProductoResource($producto, false)
             ], 200);
         } catch (\Exception $e) {
             return response()->json([
@@ -550,7 +550,7 @@ class ProductoController extends Controller
                 return response()->json(["message" => "Producto no encontrado"], 404);
             }
 
-            $imagenes = $producto->imagenes->map(function ($imagen) {
+            /* $imagenes = $producto->imagenes->map(function ($imagen) {
                 return [
                     'url_imagen' => $imagen->url_imagen,
                     'texto_alt_SEO' => $imagen->texto_alt_SEO,
@@ -579,12 +579,12 @@ class ProductoController extends Controller
                     'largo' => $producto->dimensiones->largo,
                     'ancho' => $producto->dimensiones->ancho,
                 ] : null,
-            ];
+            ]; */
 
             return response()->json([
                 'message' => 'Producto encontrado exitosamente',
-                'data' => $formattedProducto
-                //'data' => new ProductoResource($producto)
+                //'data' => $formattedProducto
+                'data' => new ProductoResource($producto, false)
             ], 200);
         } catch (\Exception $e) {
             return response()->json(["message" => "Hubo un error en el servidor"], 500);

--- a/app/Http/Resources/ProductoResource.php
+++ b/app/Http/Resources/ProductoResource.php
@@ -7,6 +7,14 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class ProductoResource extends JsonResource
 {
+    private bool $withRelacionados;
+
+    public function __construct($resource, $withRelacionados = true)
+    {
+        parent::__construct($resource);
+        $this->withRelacionados = $withRelacionados;
+    }
+
     public function toArray(Request $request): array
     {
         return [
@@ -26,7 +34,7 @@ class ProductoResource extends JsonResource
                 'ancho' => $this->dimensiones->ancho,
             ] : null,
             'imagenes' => ImagenResource::collection($this->imagenes),
-            'productos_relacionados' => ProductoRelacionadoResource::collection($this->productosRelacionados),
+            'productos_relacionados' => $this->withRelacionados ? ProductoRelacionadoResource::collection($this->productosRelacionados) : $this->productosRelacionados,
             'etiqueta' => $this->etiqueta ? [
                 'meta_titulo' => $this->etiqueta->meta_titulo,
                 'meta_descripcion' => $this->etiqueta->meta_descripcion,


### PR DESCRIPTION
- Se agregó el método resolve() para quitar el formato data que me genera por defecto el Resource collection.
- Se agregó un párametro al ProductoResource para comprobar si debemos usar el ProductoRelacionadoResource o no ya que en los endpoints de show() y showByLink() no se necesita estos datos mapeados.
<img width="474" height="492" alt="Captura de pantalla 2025-08-28 093513" src="https://github.com/user-attachments/assets/85dd17e6-2d21-4a72-ba14-ea49f43fb3ef" />
<img width="271" height="298" alt="Captura de pantalla 2025-08-28 093616" src="https://github.com/user-attachments/assets/33370c57-c28d-4220-9e1b-bbc775ed68b3" />

