### PR TITLE
fix: eliminar encoding en el metodo update del BlogController

### DIFF
--- a/app/Http/Controllers/Api/V1/Blog/BlogController.php
+++ b/app/Http/Controllers/Api/V1/Blog/BlogController.php
@@ -598,8 +598,6 @@ class BlogController extends Controller
      *                     @OA\Items(type="string", example="Durante el invierno la piel tiende a resecarse, por lo que es esencial usar cremas nutritivas.")
      *                 )
      *             ),
-     *             @OA\Encoding(name="miniatura", contentType="application/octet-stream"),
-     *             @OA\Encoding(name="imagenes[]", explode=true, contentType="application/octet-stream")
      *         )
      *     ),
      *     @OA\Response(


### PR DESCRIPTION
Los Encoding del método update en BlogController no dejaban funcionar el Swagger.
<img width="1328" height="494" alt="Captura de pantalla 2025-08-29 103015" src="https://github.com/user-attachments/assets/c519c2a0-9b98-45af-99eb-3675864c5096" />
<img width="1919" height="687" alt="Captura de pantalla 2025-08-29 103302" src="https://github.com/user-attachments/assets/e695a6bd-84cb-4c21-a3ee-55561b6581aa" />

Eliminando las siguientes líneas:
     *             @OA\Encoding(name="miniatura", contentType="application/octet-stream"),
     *             @OA\Encoding(name="imagenes[]", explode=true, contentType="application/octet-stream")
     
Permite que la documentación funcione con normalidad.
     
<img width="1469" height="908" alt="Captura de pantalla 2025-08-29 103352" src="https://github.com/user-attachments/assets/415d3297-30c5-4358-8e2e-c9b5eacb3531" />

     