### PR TITLE
Implementación de Whatsapp service en el back

### DIFF
--- a/app/Http/Controllers/Api/V1/WhatsApp/WhatsAppController.php
+++ b/app/Http/Controllers/Api/V1/WhatsApp/WhatsAppController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\WhatsApp;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+
+class WhatsAppController extends Controller
+{
+    protected $serviceUrl;
+
+    public function __construct()
+    {
+        $this->serviceUrl = env('WHATSAPP_SERVICE_URL', 'http://localhost:5111/api');
+    }
+
+    /*
+    * Login para obtener el token del whatsapp service
+    */
+    public function loginWhatsApp(Request $request) {
+        $response = Http::post($this->serviceUrl . '/auth/login', [
+            'username' => $request->username,
+            'password' => $request->password,
+        ]);
+
+        return response()->json($response->json(), $response->status());
+    }
+
+    /*
+    * Generar un QR, el emisor escanea el qr para que use su número
+    */
+    public function requestNewQr(Request $request) {
+        $token = $request->bearerToken();
+
+        $response = Http::withToken($token)->post($this->serviceUrl . '/qr-request');
+
+        return response()->json($response->json(), $response->status());
+    }
+
+    /*
+    * Envío de mensaje - con Autorización JWT
+    */
+    public function sendMessage(Request $request)
+    {
+        $request->validate([
+            'phone'          => 'required|string',
+            'templateOption' => 'required|string',
+            'psicologo'      => 'required|string',
+            'fecha'          => 'required|date',
+            'hora'           => 'required|string',
+        ]);
+
+        $token = $request->bearerToken();
+
+        $response = Http::withToken($token)
+            ->post($this->serviceUrl . '/send-message', [
+                'phone'          => $request->phone,
+                'templateOption' => $request->templateOption,
+                'psicologo'      => $request->psicologo,
+                'fecha'          => $request->fecha,
+                'hora'           => $request->hora,
+            ]);
+
+        return response()->json($response->json(), $response->status());
+    }
+
+    /*
+    * Envío de mensaje - sin Autorización JWT
+    */
+    public function sendMessageAccept(Request $request) {
+
+        $response = Http::post($this->serviceUrl . '/send-message-accept', [
+            'telefono' => $request->telefono,
+            'comentario' => $request->comentario,
+        ]);
+
+        return response()->json($response->json(), $response->status());
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Api\V1\Producto\ProductoController;
 use App\Http\Controllers\Api\V1\Cliente\ClienteController;
 use App\Http\Controllers\PermissionController;
 use App\Http\Controllers\Api\V1\Email\EmailController;
+use App\Http\Controllers\Api\V1\WhatsApp\WhatsAppController;
 use App\Http\Controllers\RoleController;
 
 
@@ -53,6 +54,13 @@ Route::prefix('v1')->group(function () {
         Route::delete('/{id}', 'destroy');
         Route::get('/link/{link}', 'showByLink');
     });
+
+    Route::prefix('whatsapp')->group(function () {
+        Route::post('/send', [WhatsAppController::class, 'sendMessage']);
+        Route::post('/loginWhatsApp', [WhatsAppController::class, 'loginWhatsApp']);
+        Route::post('/requestNewQr', [WhatsAppController::class, 'requestNewQr']);
+        Route::post('/sendMessageAccept', [WhatsAppController::class, 'sendMessageAccept']);
+    });
 });
 
 
@@ -66,7 +74,7 @@ Route::prefix('v1')->group(function () {
 //             Route::delete("/{id}", "destroy");
 //         });
 //     });
-    
+
     // Route::controller(V2ProductoController::class)->prefix('productos')->group(function(){
     //     Route::get('/', 'paginate');
     //     Route::get('/all', 'index');


### PR DESCRIPTION
Añadí el endpoint para enviar mensajes luego de haberse logueado en el servicio de whatsapp y generado el qr. El controlador toma el token que se le envía en los headers para poder utilizar el endpoint.
<img width="1027" height="611" alt="image" src="https://github.com/user-attachments/assets/99944c6a-0eca-41db-83d0-6faa1f90c84a" />

En caso no se requiera autorización entonces se utiliza el endpoint a continuación, que solo requiere telefono y comentario. Usado para comprobantes aprobados.
<img width="1061" height="706" alt="image" src="https://github.com/user-attachments/assets/84060076-20b6-4d4d-a5e3-19c60bb24467" />
