### PR TITLE
Crear endpoint para paginar "Clientes" y "Productos"

### DIFF
--- a/app/Http/Controllers/Api/V1/Cliente/ClienteController.php
+++ b/app/Http/Controllers/Api/V1/Cliente/ClienteController.php
@@ -10,6 +10,7 @@ use App\Services\ApiResponseService;
 use Illuminate\Http\Response;
 use App\Http\Contains\HttpStatusCode;
 use App\Mail\ClientRegistrationMail;
+use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
@@ -484,5 +485,17 @@ class ClienteController extends Controller
         catch(\Exception $e){
             return response()->json(['error' => 'Error al eliminar el cliente: ' . $e->getMessage()], HttpStatusCode::INTERNAL_SERVER_ERROR->value);
         }
+    }
+
+    public function paginate(Request $request)
+    {
+        $perPage = $request->get('perPage', 10);
+        $page = $request->get('page', 1);
+
+        $clientes = Cliente::paginate($perPage, ['*'], 'page', $page);
+
+        return response()->json([
+            'data'=> $clientes->items()
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/V1/Producto/ProductoController.php
+++ b/app/Http/Controllers/Api/V1/Producto/ProductoController.php
@@ -203,21 +203,10 @@ class ProductoController extends Controller
         $perPage = $request->get('perPage', 10);
         $page = $request->get('page', 1);
 
-        $productos = Producto::with('imagenes', 'productosRelacionados')->get();
-
-        $productos->transform(function ($producto) {
-            $producto->especificaciones = json_decode($producto->especificaciones, true) ?? [];
-            return $producto;
-        });
-
-        $items = $productos->forPage($page, $perPage);
+        $productos = Producto::paginate($perPage, ['*'], 'page', $page);
 
         return response()->json([
-            'data' => $items->values(),
-            'current_page' => $page,
-            'per_page' => $perPage,
-            'total' => $productos->count(),
-            'last_page' => ceil($productos->count() / $perPage),
+            'data'=> $productos->items()
         ]);
     }
 

--- a/app/Http/Controllers/Api/V1/Producto/ProductoController.php
+++ b/app/Http/Controllers/Api/V1/Producto/ProductoController.php
@@ -12,6 +12,8 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Http\Contains\HttpStatusCode;
 use App\Http\Resources\ProductoResource;
+use Illuminate\Http\Request;
+
 class ProductoController extends Controller
 {
     /**
@@ -167,6 +169,25 @@ class ProductoController extends Controller
             return response()->json([
                 'message' => 'Error al obtener los productos: ' . $e->getMessage()
             ], HttpStatusCode::INTERNAL_SERVER_ERROR->value);
+        }
+    }
+
+    /**
+     * Get all related products by id
+     */
+    public function related($id)
+    {
+        try {
+            $producto = Producto::with(['productosRelacionados'])->findOrFail($id);
+
+            return response()->json([
+                'producto' => $producto->nombre,
+                'relacionados' => $producto->productosRelacionados
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'message' => 'Error al obtener productos relacionados: ' . $e->getMessage()
+            ], 500);
         }
     }
 

--- a/database/factories/ClienteFactory.php
+++ b/database/factories/ClienteFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Cliente>
+ */
+class ClienteFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->name(),
+            'email' => $this->faker->email(),
+            'celular' => $this->faker->numerify('9########'),
+        ];
+    }
+}

--- a/database/seeders/ClienteSeeder.php
+++ b/database/seeders/ClienteSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Cliente;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class ClienteSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Cliente::factory()->count(20)->create();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,6 +23,10 @@ Route::prefix('v1')->group(function () {
         Route::apiResource('users', UserController::class);
     });
 
+    Route::controller(ClienteController::class)->prefix('clientes')->group(function () {
+        Route::get('/paginate', 'paginate');
+    });
+    
     Route::apiResource('clientes', ClienteController::class);
 
     Route::controller(BlogController::class)->prefix('blogs')->group(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -45,6 +45,9 @@ Route::prefix('v1')->group(function () {
         Route::get('/', 'index');
         Route::get('/{id}', 'show');
 
+        Route::get('/{id}/related', 'related');
+        //Route::get('/paginate', 'paginate');
+
         Route::middleware(['auth:sanctum', 'role:ADMIN|USER', 'permission:ENVIAR'])->group(function () {});
 
         Route::post('/', 'store');

--- a/routes/api.php
+++ b/routes/api.php
@@ -43,10 +43,10 @@ Route::prefix('v1')->group(function () {
 
     Route::controller(ProductoController::class)->prefix('productos')->group(function(){
         Route::get('/', 'index');
+        Route::get('/paginate', 'paginate');
         Route::get('/{id}', 'show');
 
         Route::get('/{id}/related', 'related');
-        //Route::get('/paginate', 'paginate');
 
         Route::middleware(['auth:sanctum', 'role:ADMIN|USER', 'permission:ENVIAR'])->group(function () {});
 


### PR DESCRIPTION
Endpoint optimizado usando la función de "paginate".
Contiene dos parámetros:
- `perPage`: Indica el rango de productos o clientes que se mostrará.
- `page`: Indica la posición inicial.