### PR TITLE
fix: reemplazar método PUT por POST para compatibilidad al actualizar los blogs

### DIFF
--- a/app/Http/Requests/PostBlog/UpdateBlog.php
+++ b/app/Http/Requests/PostBlog/UpdateBlog.php
@@ -22,18 +22,25 @@ class UpdateBlog extends FormRequest
      */
     public function rules(): array
     {
-        $isPut = $this->isMethod('put');
-        $required = $isPut ? 'required' : 'sometimes';
+        /* $isPut = $this->isMethod('put');
+        $required = $isPut ? 'required' : 'sometimes'; */
         $blogId = $this->route('blog');
 
         return [
-            'titulo' => [$required, 'string', 'max:255'],
+            /* 'titulo' => [$required, 'string', 'max:255'],
             'producto_id' => [$required, 'integer', 'exists:productos,id'],
             'link' => [$required, 'string', 'max:255', Rule::unique('blogs', 'link')->ignore($blogId)],
             'subtitulo1' => [$required, 'string', 'max:255'],
             'subtitulo2' => [$required, 'string', 'max:255'],
             'video_url' => [$required, 'url'],
-            'video_titulo' => [$required, 'string', 'max:255'],
+            'video_titulo' => [$required, 'string', 'max:255'], */
+            'titulo' => ['required', 'string', 'max:255'],
+            'producto_id' => ['required', 'integer', 'exists:productos,id'],
+            'link' => ['required', 'string', 'max:255', Rule::unique('blogs', 'link')->ignore($blogId)],
+            'subtitulo1' => ['required', 'string', 'max:255'],
+            'subtitulo2' => ['required', 'string', 'max:255'],
+            'video_url' => ['required', 'url'],
+            'video_titulo' => ['required', 'string', 'max:255'],
 
             'meta_titulo' => 'nullable|string|min:10|max:60',
             'meta_descripcion' => 'nullable|string|min:40|max:160',
@@ -42,11 +49,17 @@ class UpdateBlog extends FormRequest
             'imagenes' => ['sometimes', 'array'],
             'imagenes.*' => ['sometimes', 'image', 'max:2048'],
 
-            'text_alt' => [$isPut ? 'required' : 'sometimes', 'array'],
+            /* 'text_alt' => [$isPut ? 'required' : 'sometimes', 'array'],
             'text_alt.*' => [$isPut ? 'required' : 'sometimes', 'string', 'max:255'],
 
             'parrafos' => [$isPut ? 'required' : 'sometimes', 'array'],
-            'parrafos.*' => [$isPut ? 'required' : 'sometimes', 'string', 'max:2047'],
+            'parrafos.*' => [$isPut ? 'required' : 'sometimes', 'string', 'max:2047'], */
+
+            'text_alt' => ['required', 'array'],
+            'text_alt.*' => ['required', 'string', 'max:255'],
+
+            'parrafos' => ['required', 'array'],
+            'parrafos.*' => ['required', 'string', 'max:2047'],
         ];
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -33,8 +33,8 @@ Route::prefix('v1')->group(function () {
 
         Route::middleware(['auth:sanctum', 'role:ADMIN'])->group(function () {});
         Route::post('/', 'store');
-        Route::put('/{blog}', 'update');
-        Route::patch('/{blog}', 'update');
+        Route::post('/{blog}', 'update');
+        //Route::patch('/{blog}', 'update');
         Route::delete('/{blog}', 'destroy');
     });
 


### PR DESCRIPTION
La función update no se utilizará el método HTTP PUT ni PATCH, se reemplaza por POST para manejar la compatibilidad porque PHP no parsea multipart/form-data en PUT.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/48572c42-8099-460d-b87b-2ab60f69b642" />

Con este cambio la actualización se realiza correctamente. Además se comentó la lógica de required y sometimes de acuerdo a PUT y PATCH debido a que estos métodos ya no se usan. En consecuencia se cambió a required todos los campos que aplicaban esta lógica.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f902da32-ae5d-4443-a5a3-d1acb4362464" />
